### PR TITLE
Add option to toggle CJK line breaking rules.

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -398,6 +398,7 @@ private:
 	void _update_scroll();
 	void _update_fx(ItemFrame *p_frame, float p_delta_time);
 	void _scroll_changed(double);
+	void _settings_changed();
 
 	void _gui_input(Ref<InputEvent> p_event);
 	Item *_get_next_item(Item *p_item, bool p_free = false);


### PR DESCRIPTION
This adds a feature to RichTextLabel nodes. When a RichTextLabel is changed it now queries the "rich_text/force_cjk_linebreaks" setting. If the setting exists AND is enabled then all rich text is treated as CJK text. If the setting does not exist OR is not enabled then the previously implemented behavior (CJK detection by scanning text) is used.

"rich_text/force_cjk_linebreaks" is the default name for the setting. However, the name of the setting can be changed at compile-time by defining GNOMESORT_CJK_LINEBREAK_SETTING to your preferred string.

To support this, RichTextLabels now connect to the ProjectSettings::on_settings_changed signal. When the signal is emitted, RichTextLabels will invalidate their current formatting and update. This forces the CJK line break setting to be queried again. A method is added to RichTextLabel called _settings_changed to facilitate this.

Obviously, projects don't have this setting by default so it will need to be added. Once "rich_text/force_cjk_linebreaks" (or an equivalent) has been added to the project it can be toggled from GDScript.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
